### PR TITLE
Add MostPaintingsView with segmented toggle for most expensive paintings

### DIFF
--- a/PaintingsGemini/PaintingsGeminiApp.swift
+++ b/PaintingsGemini/PaintingsGeminiApp.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct PaintingsGeminiApp: App {
     var body: some Scene {
         WindowGroup {
-            PaintingsGeminiView()
+            MostPaintingsView()
         }
     }
 }

--- a/PaintingsGemini/Views/MostPaintingsView.swift
+++ b/PaintingsGemini/Views/MostPaintingsView.swift
@@ -1,0 +1,78 @@
+//
+//  MostPaintingsView.swift
+//  PaintingsGemini
+//
+//  Created by Tatiana Kornilova on 22/01/2026.
+//
+
+import SwiftUI
+
+struct MostPaintingsView: View {
+    enum Mode: String, CaseIterable, Identifiable {
+        case browse = "Browse"
+        case mostExpensive = "Most Expensive"
+
+        var id: String { rawValue }
+    }
+
+    @State private var mode: Mode = .browse
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 12) {
+                Picker("View", selection: $mode) {
+                    ForEach(Mode.allCases) { mode in
+                        Text(mode.rawValue).tag(mode)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .padding(.horizontal)
+
+                Group {
+                    switch mode {
+                    case .browse:
+                        PaintingsGeminiView()
+                    case .mostExpensive:
+                        MostExpensivePaintingsView()
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct MostExpensivePaintingsView: View {
+    @State var vm = PaintingsGeminiViewModel()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Most expensive paintings from the local collection.")
+                .font(.headline)
+                .padding(.horizontal)
+
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 16) {
+                    ForEach(topPaintings) { painting in
+                        ArtWorkView(painting: painting)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal)
+            }
+        }
+        .onAppear {
+            vm.load()
+            ImageStringCache.shared.clearCache()
+        }
+        .navigationTitle("Most Expensive")
+    }
+
+    private var topPaintings: [PaintingGemini] {
+        let sorted = vm.paintings.sorted { $0.cost > $1.cost }
+        return Array(sorted.prefix(10))
+    }
+}
+
+#Preview {
+    MostPaintingsView()
+}


### PR DESCRIPTION
### Motivation
- Provide an entry point that lets users switch between the existing browsing UI and a new view that surfaces the most expensive paintings from the local collection.
- Make it easy to inspect top-valued items without disturbing the existing `PaintingsGeminiView` implementation.

### Description
- Add `MostPaintingsView` in `PaintingsGemini/Views/MostPaintingsView.swift` which contains a segmented `Picker` to switch between `PaintingsGeminiView` and `MostExpensivePaintingsView`.
- Implement `MostExpensivePaintingsView` which loads the local collection via `PaintingsGeminiViewModel`, sorts by the `cost` computed property, and displays the top 10 entries using `ArtWorkView`.
- Call `vm.load()` and clear `ImageStringCache` on appear in the most-expensive view to ensure data and images are refreshed.
- Update the app entry point in `PaintingsGeminiApp.swift` to launch `MostPaintingsView` as the initial view.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698719db3bf8832fa8241d8ffb1d9182)