### PR TITLE
Add retry control for artwork image loads

### DIFF
--- a/PaintingsGemini/Views/ArtWorkView.swift
+++ b/PaintingsGemini/Views/ArtWorkView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 struct ArtWorkView: View {
     let painting: Art //PaintingGemini
     @Environment(\.displayScale) private var displayScale
+    @State private var reloadToken = UUID()
     
     var body: some View {
         VStack  (alignment: .leading){
@@ -27,8 +28,9 @@ struct ArtWorkView: View {
                 Text(painting.style)
                     .foregroundStyle(.secondary)
             }
-            if let url = URL (string: painting.imageURL)/*painting.URLImage*/ {
-                if let cached = ImageStringCache.shared.image (for: painting.title + painting.artist) {
+            let cacheKey = painting.title + painting.artist
+            if let url = URL(string: painting.imageURL)/*painting.URLImage*/ {
+                if let cached = ImageStringCache.shared.image(for: cacheKey) {
                     Text("--- Cached Image ---")
                     Image(uiImage: cached)
                         .resizable()
@@ -52,18 +54,25 @@ struct ArtWorkView: View {
                                     let renderer = ImageRenderer(content: image)
                                     renderer.scale = displayScale
                                     if let uiImage = renderer.uiImage {
-                                        ImageStringCache.shared.store(uiImage, for: painting.title + painting.artist)
+                                        ImageStringCache.shared.store(uiImage, for: cacheKey)
                                     }
                                 }
                         case .failure:
-                            Image(systemName: "photo")
-                                .frame(width: 80, height: 80)
-                                .foregroundStyle(.secondary)
+                            VStack(spacing: 8) {
+                                Image(systemName: "photo")
+                                    .frame(width: 80, height: 80)
+                                    .foregroundStyle(.secondary)
+                                Button("Retry") {
+                                    reloadToken = UUID()
+                                }
+                                .buttonStyle(.bordered)
+                            }
                             
                         @unknown default:
                             EmptyView()
                         }
                     }
+                    .id(reloadToken)
                 }
             }
         }


### PR DESCRIPTION
### Motivation
- Failed artwork image loads were not easily recoverable when presented inside `ScrollView`/`LazyVStack`, so provide an explicit retry mechanism and consistent cache usage so images can be re-fetched without leaving the view.

### Description
- Add `@State private var reloadToken = UUID()` and attach `.id(reloadToken)` to the `AsyncImage` so changing the token forces the `AsyncImage` to be recreated, show a `Retry` button in the `.failure` phase that updates `reloadToken` to restart the fetch, and introduce a local `cacheKey` used for both lookup and storage in `ImageStringCache`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698729bf968c832f9fe5de1d3dc6b39f)