### PR TITLE
Replace segmented Picker with TabView and share PaintingsGeminiViewModel

### DIFF
--- a/PaintingsGemini/Views/MostPaintingsView.swift
+++ b/PaintingsGemini/Views/MostPaintingsView.swift
@@ -8,34 +8,20 @@
 import SwiftUI
 
 struct MostPaintingsView: View {
-    enum Mode: String, CaseIterable, Identifiable {
-        case browse = "Browse"
-        case mostExpensive = "Most Expensive"
-
-        var id: String { rawValue }
-    }
-
-    @State private var mode: Mode = .browse
+    @State private var viewModel = PaintingsGeminiViewModel()
 
     var body: some View {
         NavigationStack {
-            VStack(spacing: 12) {
-                Picker("View", selection: $mode) {
-                    ForEach(Mode.allCases) { mode in
-                        Text(mode.rawValue).tag(mode)
+            TabView {
+                PaintingsGeminiView(viewModel: viewModel)
+                    .tabItem {
+                        Label("Artists", systemImage: "person.3.fill")
                     }
-                }
-                .pickerStyle(.segmented)
-                .padding(.horizontal)
 
-                Group {
-                    switch mode {
-                    case .browse:
-                        PaintingsGeminiView()
-                    case .mostExpensive:
-                        MostExpensivePaintingsView()
+                MostExpensivePaintingsView()
+                    .tabItem {
+                        Label("Expensive Paintings", systemImage: "dollarsign.circle")
                     }
-                }
             }
         }
     }

--- a/PaintingsGemini/Views/PaintingsGeminiView.swift
+++ b/PaintingsGemini/Views/PaintingsGeminiView.swift
@@ -50,8 +50,7 @@ final class PaintingsGeminiViewModel {
 }
 
 struct PaintingsGeminiView: View {
-  
-    @State var vm = PaintingsGeminiViewModel()
+    @State var viewModel: PaintingsGeminiViewModel
     @State private var searchText = ""
     @State var selectedArtist = "Claude Monet"
 
@@ -76,7 +75,7 @@ struct PaintingsGeminiView: View {
         }
         .padding(.horizontal)
         .onAppear {
-            vm.load()
+            viewModel.load()
             ImageStringCache.shared.clearCache()
         }
         .navigationTitle("Paintings Gemini")
@@ -88,9 +87,9 @@ struct PaintingsGeminiView: View {
     }
     var filteredArtists: [ArtistItem]  {
         if searchText.isEmpty {
-            return vm.artistItems
+            return viewModel.artistItems
         } else {
-            return vm.artistItems.filter {
+            return viewModel.artistItems.filter {
                 $0.name.localizedCaseInsensitiveContains(searchText)
             }
         }
@@ -98,9 +97,9 @@ struct PaintingsGeminiView: View {
     
     var filteredPaintings: [PaintingGemini]  {
         if selectedArtist.isEmpty {
-            return vm.paintings
+            return viewModel.paintings
         } else {
-            return vm.paintings.filter {
+            return viewModel.paintings.filter {
                 $0.artist.localizedCaseInsensitiveContains(selectedArtist)
             }
         }
@@ -108,5 +107,5 @@ struct PaintingsGeminiView: View {
 }
 
 #Preview {
-    PaintingsGeminiView()
+    PaintingsGeminiView(viewModel: PaintingsGeminiViewModel())
 }


### PR DESCRIPTION
### Motivation
- Replace the segmented `Picker` navigation with a tabbed interface to provide clearer, more standard navigation between artist browsing and the most expensive paintings.
- Share a single `PaintingsGeminiViewModel` instance so the Artists tab can reuse loaded data and avoid duplicated loads.

### Description
- Replaced the segmented `Picker` in `MostPaintingsView` with a `TabView` containing `PaintingsGeminiView` and `MostExpensivePaintingsView`.
- Introduced a shared `@State private var viewModel = PaintingsGeminiViewModel()` in `MostPaintingsView` and pass it into `PaintingsGeminiView` as `viewModel`.
- Updated `PaintingsGeminiView` to accept `@State var viewModel: PaintingsGeminiViewModel` and replaced internal `vm` references with `viewModel` usages.
- Updated the `PaintingsGeminiView` preview to instantiate the view with `PaintingsGeminiView(viewModel: PaintingsGeminiViewModel())`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698730689b84832f88f2c0e33778ac7a)