### PR TITLE
Initialize PaintingsGeminiViewModel on app launch

### DIFF
--- a/PaintingsGemini/PaintingsGeminiApp.swift
+++ b/PaintingsGemini/PaintingsGeminiApp.swift
@@ -9,9 +9,17 @@ import SwiftUI
 
 @main
 struct PaintingsGeminiApp: App {
+    @State private var viewModel: PaintingsGeminiViewModel
+
+    init() {
+        let viewModel = PaintingsGeminiViewModel()
+        viewModel.load()
+        _viewModel = State(initialValue: viewModel)
+    }
+
     var body: some Scene {
         WindowGroup {
-            MostPaintingsView()
+            MostPaintingsView(viewModel: viewModel)
         }
     }
 }

--- a/PaintingsGemini/Views/MostPaintingsView.swift
+++ b/PaintingsGemini/Views/MostPaintingsView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct MostPaintingsView: View {
-    @State private var viewModel = PaintingsGeminiViewModel()
+    @Bindable var viewModel: PaintingsGeminiViewModel
 
     var body: some View {
         NavigationStack {
@@ -18,7 +18,7 @@ struct MostPaintingsView: View {
                         Label("Artists", systemImage: "person.3.fill")
                     }
 
-                MostExpensivePaintingsView()
+                MostExpensivePaintingsView(viewModel: viewModel)
                     .tabItem {
                         Label("Expensive Paintings", systemImage: "dollarsign.circle")
                     }
@@ -28,7 +28,7 @@ struct MostPaintingsView: View {
 }
 
 struct MostExpensivePaintingsView: View {
-    @State var vm = PaintingsGeminiViewModel()
+    @Bindable var viewModel: PaintingsGeminiViewModel
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -46,19 +46,15 @@ struct MostExpensivePaintingsView: View {
                 .padding(.horizontal)
             }
         }
-        .onAppear {
-            vm.load()
-            ImageStringCache.shared.clearCache()
-        }
         .navigationTitle("Most Expensive")
     }
 
     private var topPaintings: [PaintingGemini] {
-        let sorted = vm.paintings.sorted { $0.cost > $1.cost }
+        let sorted = viewModel.paintings.sorted { $0.cost > $1.cost }
         return Array(sorted.prefix(10))
     }
 }
 
 #Preview {
-    MostPaintingsView()
+    MostPaintingsView(viewModel: PaintingsGeminiViewModel())
 }

--- a/PaintingsGemini/Views/PaintingsGeminiView.swift
+++ b/PaintingsGemini/Views/PaintingsGeminiView.swift
@@ -50,7 +50,7 @@ final class PaintingsGeminiViewModel {
 }
 
 struct PaintingsGeminiView: View {
-    @State var viewModel: PaintingsGeminiViewModel
+    @Bindable var viewModel: PaintingsGeminiViewModel
     @State private var searchText = ""
     @State var selectedArtist = "Claude Monet"
 
@@ -75,7 +75,6 @@ struct PaintingsGeminiView: View {
         }
         .padding(.horizontal)
         .onAppear {
-            viewModel.load()
             ImageStringCache.shared.clearCache()
         }
         .navigationTitle("Paintings Gemini")


### PR DESCRIPTION
### Motivation
- Load the paintings data once at application startup so the same model instance is shared across views and avoids redundant loading.
- Pass a single observable view model through the tab hierarchy so lists and derived views read from a single source of truth.

### Description
- Added a `@State private var viewModel: PaintingsGeminiViewModel` to `PaintingsGeminiApp` and call `viewModel.load()` in its `init()` to load data once at launch.
- Pass the shared `viewModel` into `MostPaintingsView` via its initializer instead of creating per-view instances.
- Converted local view model properties to `@Bindable var viewModel: PaintingsGeminiViewModel` in `MostPaintingsView`, `MostExpensivePaintingsView`, and `PaintingsGeminiView` so child views observe the shared model.
- Removed per-view `load()` calls and updated usages to read from the shared `viewModel` (including `topPaintings` and previews).

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69875248bbf0832f82f733fd9df06b40)