### PR TITLE
Load paintings in ViewModel init and simplify App initialization

### DIFF
--- a/PaintingsGemini/PaintingsGeminiApp.swift
+++ b/PaintingsGemini/PaintingsGeminiApp.swift
@@ -9,13 +9,7 @@ import SwiftUI
 
 @main
 struct PaintingsGeminiApp: App {
-    @State private var viewModel: PaintingsGeminiViewModel
-
-    init() {
-        let viewModel = PaintingsGeminiViewModel()
-        viewModel.load()
-        _viewModel = State(initialValue: viewModel)
-    }
+    @State private var viewModel = PaintingsGeminiViewModel()
 
     var body: some Scene {
         WindowGroup {

--- a/PaintingsGemini/Views/PaintingsGeminiView.swift
+++ b/PaintingsGemini/Views/PaintingsGeminiView.swift
@@ -40,6 +40,10 @@ final class PaintingsGeminiViewModel {
             .sorted { $0.name < $1.name}
     }
 
+    init() {
+        load()
+    }
+
     func load() {
         do {
             paintings = try PaintingsGeminiLoader.loadFromBundle()


### PR DESCRIPTION
### Motivation
- Move the responsibility for loading painting data into the view model so the `App` type does not perform explicit preloading in its initializer.
- Simplify application startup by using default `@State` initialization for the view model in the `App` entry point.

### Description
- Replaced the custom `init()` in `PaintingsGeminiApp` with `@State private var viewModel = PaintingsGeminiViewModel()` in `PaintingsGeminiApp.swift`.
- Added an `init()` to `PaintingsGeminiViewModel` that calls `load()` so the model populates `paintings` on creation in `PaintingsGemini/Views/PaintingsGeminiView.swift`.
- Kept the existing `load()` implementation unchanged so bundle JSON decoding behavior is preserved.

### Testing
- No automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987658d5124832fb8705caae288f4b3)