### PR TITLE
Move image cache clearing into view model init

### DIFF
--- a/PaintingsGemini/Views/PaintingsGeminiView.swift
+++ b/PaintingsGemini/Views/PaintingsGeminiView.swift
@@ -41,6 +41,7 @@ final class PaintingsGeminiViewModel {
     }
 
     init() {
+        ImageStringCache.shared.clearCache()
         load()
     }
 
@@ -78,9 +79,6 @@ struct PaintingsGeminiView: View {
             }
         }
         .padding(.horizontal)
-        .onAppear {
-            ImageStringCache.shared.clearCache()
-        }
         .navigationTitle("Paintings Gemini")
         .onChange(of: filteredArtists) {
             if  !filteredArtists.isEmpty && !filteredArtists.map({$0.name}).contains(selectedArtist) {


### PR DESCRIPTION
### Motivation
- Ensure the image cache is cleared when the view model is created instead of when the view appears, centralizing lifecycle behavior and avoiding repeated clears on view appearance.

### Description
- Add `ImageStringCache.shared.clearCache()` to `PaintingsGeminiViewModel` initializer in `PaintingsGeminiView.swift`.
- Remove the `.onAppear { ImageStringCache.shared.clearCache() }` call from `PaintingsGeminiView` in `PaintingsGeminiView.swift`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987692bb928832f8c58f8bfba3d0271)