### PR TITLE
Add TitlePaintingsView and Titles tab to MostPaintingsView

### DIFF
--- a/PaintingsGemini/Views/MostPaintingsView.swift
+++ b/PaintingsGemini/Views/MostPaintingsView.swift
@@ -22,6 +22,11 @@ struct MostPaintingsView: View {
                     .tabItem {
                         Label("Expensive Paintings", systemImage: "dollarsign.circle")
                     }
+
+                TitlePaintingsView(viewModel: viewModel)
+                    .tabItem {
+                        Label("Titles", systemImage: "text.magnifyingglass")
+                    }
             }
         }
     }

--- a/PaintingsGemini/Views/TitlePaintingsView.swift
+++ b/PaintingsGemini/Views/TitlePaintingsView.swift
@@ -1,0 +1,48 @@
+//
+//  TitlePaintingsView.swift
+//  PaintingsGemini
+//
+//  Created by Tatiana Kornilova on 22/01/2026.
+//
+
+import SwiftUI
+
+struct TitlePaintingsView: View {
+    @Bindable var viewModel: PaintingsGeminiViewModel
+    @State private var titleQuery = ""
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Filter paintings by title.")
+                .font(.headline)
+
+            TextField("Search title", text: $titleQuery, axis: .vertical)
+                .textFieldStyle(.roundedBorder)
+                .submitLabel(.search)
+
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 16) {
+                    ForEach(filteredPaintings) { painting in
+                        ArtWorkView(painting: painting)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .padding(.horizontal)
+        .navigationTitle("Titles")
+    }
+
+    private var filteredPaintings: [PaintingGemini] {
+        if titleQuery.isEmpty {
+            return viewModel.paintings
+        }
+        return viewModel.paintings.filter {
+            $0.title.localizedCaseInsensitiveContains(titleQuery)
+        }
+    }
+}
+
+#Preview {
+    TitlePaintingsView(viewModel: PaintingsGeminiViewModel())
+}


### PR DESCRIPTION
### Motivation
- Provide a way to filter and browse paintings by title from the local collection.
- Expose the title-based filter as a separate tab in the main `MostPaintingsView` navigation.

### Description
- Add new SwiftUI view `TitlePaintingsView` at `PaintingsGemini/Views/TitlePaintingsView.swift` which declares `@Bindable var viewModel: PaintingsGeminiViewModel`, a `@State` `titleQuery`, a `TextField` for entering the title filter, and a filtered list that displays matching `PaintingGemini` items using `ArtWorkView`.
- Update `PaintingsGemini/Views/MostPaintingsView.swift` to include `TitlePaintingsView(viewModel: viewModel)` as a new tab with the label `Titles` and system image `text.magnifyingglass`.
- Keep existing layout and navigation behavior by using the same `ScrollView`/`LazyVStack` pattern and setting `.navigationTitle("Titles")` for the new view.

### Testing
- No automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69884c17e734832f97be6ceeb222131e)