### PR TITLE
Replace artist picker with searchable bottom sheet

### DIFF
--- a/PaintingsGemini/ViewModels/PaintingsGeminiViewModel.swift
+++ b/PaintingsGemini/ViewModels/PaintingsGeminiViewModel.swift
@@ -31,23 +31,6 @@ enum PaintingsGeminiLoader {
 @Observable @MainActor
 final class PaintingsGeminiViewModel {
     var paintings: [PaintingGemini] = []
-    var searchText: String = "" {
-        didSet {
-            // debounce 300ms
-            searchDebounceTask?.cancel()
-            searchDebounceTask = Task { [searchText] in
-                do {
-                    try await Task.sleep(for: .milliseconds(300))
-                    guard !Task.isCancelled else { return }
-                    self.debouncedSearchText = searchText
-                } catch is CancellationError {
-                    return
-                } catch {
-                    return
-                }
-            }
-        }
-    }
     var selectedArtist: String = ""
     var artists: [String] {
         Array(Set(paintings.map { $0.artist }))
@@ -58,10 +41,6 @@ final class PaintingsGeminiViewModel {
         }.map { ArtistItem(name: $0.key, count: $0.value) }
             .sorted { $0.name < $1.name }
     }
-
-    // Debounced search support
-    var debouncedSearchText: String = ""
-    private var searchDebounceTask: Task<Void, Never>? = nil
 
     init() {
         ImageStringCache.shared.clearCache()
@@ -78,27 +57,18 @@ final class PaintingsGeminiViewModel {
         }
     }
     
-    func filteredArtists(searchText: String) -> [ArtistItem] {
-        if searchText.isEmpty {
-            return artistItems
-        }
-        return artistItems.filter { $0.name.localizedStandardContains(searchText) }
-    }
-
     func filteredPaintings(selectedArtist: String) -> [PaintingGemini] {
         if selectedArtist.isEmpty {
             return paintings
         }
         return paintings.filter { $0.artist == selectedArtist }
     }
-    
-    // In PaintingsGeminiViewModel
+
     func ensureValidSelection() {
-        let currentArtists = filteredArtists(searchText: debouncedSearchText)
+        let currentArtists = artistItems
         let currentArtistNames = Set(currentArtists.map(\.name))
 
         if !currentArtists.isEmpty,
-    //       !currentArtists.map(\.name).contains(selectedArtist),
            !currentArtistNames.contains(selectedArtist),
            let first = currentArtists.first {
             selectedArtist = first.name

--- a/PaintingsGemini/Views/ArtistPickerView.swift
+++ b/PaintingsGemini/Views/ArtistPickerView.swift
@@ -8,17 +8,59 @@ import SwiftUI
 
 struct ArtistPickerView: View {
     let filteredArtists: [ArtistItem]
-    @Binding  var selectedArtist: String
+    @Binding var selectedArtist: String
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var searchText = ""
 
     var body: some View {
-        VStack {
-            Picker("Artist", selection: $selectedArtist) {
-                ForEach(filteredArtists, id: \.name) { artist in
-                    Text("\(artist.name) (\(artist.count))")
-                        .tag(artist.name)
+        NavigationStack {
+            let artists = searchText.isEmpty
+                ? filteredArtists
+                : filteredArtists.filter { $0.name.localizedStandardContains(searchText) }
+
+            List {
+                Section("Created by") {
+                    ForEach(artists, id: \.name) { artist in
+                        Button {
+                            selectedArtist = artist.name
+                            dismiss()
+                        } label: {
+                            HStack {
+                                Text(artist.name)
+                                Spacer()
+                                if artist.name == selectedArtist {
+                                    Image(systemName: "checkmark")
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                        .foregroundStyle(.primary)
+                    }
                 }
             }
+            .listStyle(.plain)
+            .navigationTitle("Artist")
+            .navigationBarTitleDisplayMode(.inline)
+            .safeAreaInset(edge: .top) {
+                HStack {
+                    Image(systemName: "magnifyingglass")
+                        .foregroundStyle(.secondary)
+
+                    TextField("Search artist", text: $searchText)
+                        .textInputAutocapitalization(.words)
+                        .autocorrectionDisabled()
+                }
+                .padding(.horizontal)
+                .padding(.vertical, 12)
+                .overlay {
+                    RoundedRectangle(cornerRadius: 24)
+                        .stroke(.primary, lineWidth: 1)
+                }
+                .padding(.horizontal)
+                .padding(.top)
+                .background(.background)
+            }
         }
-        .navigationTitle("Artist")
     }
 }

--- a/PaintingsGemini/Views/PaintingsGeminiView.swift
+++ b/PaintingsGemini/Views/PaintingsGeminiView.swift
@@ -11,34 +11,33 @@ struct PaintingsGeminiView: View {
     var isSelected: Bool
     
     @Bindable var viewModel: PaintingsGeminiViewModel
-    @FocusState private var isArtistFieldFocused: Bool
+    @State private var isArtistSheetPresented = false
 
     var body: some View {
         VStack {
-            let artists = viewModel.filteredArtists(searchText: viewModel.debouncedSearchText)
             let paintings = viewModel.filteredPaintings(selectedArtist: viewModel.selectedArtist)
-            let artistNames = Set(artists.map(\.name))
 
             Text("Choose the artist to fetch paintings from local DB.")
-            TextField("Search artist", text: $viewModel.searchText, axis: .vertical)
-                .font(.headline)
-                .textFieldStyle(.roundedBorder)
-                .focused($isArtistFieldFocused)
-                .textInputAutocapitalization(.words)
-                .autocorrectionDisabled()
-                .submitLabel(.search)
-                .onSubmit {
-                    if let first = artists.first {
-                        viewModel.selectedArtist = first.name
-                    }
+
+            Button {
+                isArtistSheetPresented = true
+            } label: {
+                HStack {
+                    Text(viewModel.selectedArtist.isEmpty ? "Search artist" : viewModel.selectedArtist)
+                        .foregroundStyle(viewModel.selectedArtist.isEmpty ? .secondary : .primary)
+                    Spacer()
+                    Image(systemName: "chevron.up.chevron.down")
+                        .foregroundStyle(.secondary)
                 }
-            
-          //  if artists.map({ $0.name }).contains(viewModel.selectedArtist) {
-            if artistNames.contains(viewModel.selectedArtist) {
-                ArtistPickerView(filteredArtists: artists, selectedArtist: $viewModel.selectedArtist)
-            } else {
-                Text(viewModel.selectedArtist)
+                .padding(.horizontal)
+                .padding(.vertical, 12)
+                .overlay {
+                    RoundedRectangle(cornerRadius: 10)
+                        .stroke(.quaternary, lineWidth: 1)
+                }
             }
+            .buttonStyle(.plain)
+
             if paintings.isEmpty {
                 ContentUnavailableView("No paintings", systemImage: "photo.on.rectangle.angled", description: Text("Try another artist or clear search"))
             } else {
@@ -54,18 +53,17 @@ struct PaintingsGeminiView: View {
                 viewModel.selectedArtist = first
             }
         }
-        .onChange(of: viewModel.debouncedSearchText) { _, _ in
-            viewModel.ensureValidSelection()
-        }
         .onChange(of: viewModel.artistItems) { _, _ in
             viewModel.ensureValidSelection()
         }
+        .sheet(isPresented: $isArtistSheetPresented) {
+            ArtistPickerView(filteredArtists: viewModel.artistItems, selectedArtist: $viewModel.selectedArtist)
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
+        }
         .onChange(of: isSelected) { _, newValue in
             if newValue {
-                Task { @MainActor in
-                    try? await Task.sleep(for: .milliseconds(100))
-                    isArtistFieldFocused = true
-                }
+                isArtistSheetPresented = true
             }
         }
     }


### PR DESCRIPTION
### Motivation
- Replace the inline `TextField` + `Picker` artist selection with a bottom sheet that matches the requested UI: a searchable list that appears from the bottom when the selector is tapped. 
- Make it easier to find artists by name via a search field and provide a clearer dismiss/select flow (tap to pick and close sheet).

### Description
- Replaced the `TextField` + `Picker` flow in `PaintingsGeminiView` with a tappable selector row that presents a sheet; the sheet uses `.presentationDetents([.medium, .large])` and `.presentationDragIndicator(.visible)` and shows the current selection in the selector control (`PaintingsGemini/Views/PaintingsGeminiView.swift`).
- Reworked `ArtistPickerView` into a `NavigationStack` + `List` containing a search `TextField` (placed in `.safeAreaInset(edge: .top)`), filtered results using `localizedStandardContains`, tap-to-select rows with a checkmark for the current artist, and dismiss-on-select behavior (`PaintingsGemini/Views/ArtistPickerView.swift`).
- Simplified `PaintingsGeminiViewModel` by removing the debounced search state and related properties/methods that were only used by the previous inline picker implementation, and updated `ensureValidSelection()` to validate against `artistItems` (`PaintingsGemini/ViewModels/PaintingsGeminiViewModel.swift`).
- Files changed: `PaintingsGemini/Views/PaintingsGeminiView.swift`, `PaintingsGemini/Views/ArtistPickerView.swift`, and `PaintingsGemini/ViewModels/PaintingsGeminiViewModel.swift`.

### Testing
- Attempted `swiftlint` as an automated style check but it is not installed in this environment, so the check was not run. 
- Attempted to run `xcodebuild -list -project PaintingsGemini.xcodeproj` to verify the Xcode project build configuration, but `xcodebuild` is unavailable in this environment, so the build check was not run. 
- Attempted an automated UI capture via Playwright, but the run failed because there is no local web endpoint for this iOS app in the container, so no UI screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7b847ffd0832f94be9bbd1d30f594)